### PR TITLE
Unblock docker REST API registry PUT requests

### DIFF
--- a/apache-site.conf
+++ b/apache-site.conf
@@ -24,6 +24,7 @@
   # When FRONTEND_BROWSE_ONLY_MODE is defined in envvars
   # we will only allow GET requests to the frontend. All other
   # HTTP requests will be aborted with a HTTP 403 Error.
+  # All docker registry REST API requests are allowed. 
 
   <IfDefine FRONTEND_BROWSE_ONLY_MODE>
     <Location />
@@ -31,6 +32,10 @@
         Order Allow,Deny
         Deny From All
       </LimitExcept>
+    </Location>
+    <Location /v2/>
+      Order Allow,Deny
+      Allow From All
     </Location>
   </IfDefine>
 


### PR DESCRIPTION
According to the Apache config documentation, the <IfDefine> container is evaluated at server startup and restart. If the condition is true, then the enclosed directives will be applied to all requests. Since FRONTEND_BROWSE_ONLY_MODE is set by default, only GET requests were passed to the Docker Registry but no PUT requests. Therefore the command "docker push <image>" throws an 403 error when using this docker registry frontend as a proxy for the docker registry.
